### PR TITLE
Hide $0.00 Tax

### DIFF
--- a/app/partials/controls/orderSummary.html
+++ b/app/partials/controls/orderSummary.html
@@ -22,7 +22,7 @@
         </p>
         <p ng-if="!(user.Permissions.contains('HidePricing'))">
             <span class="text-info">{{'Tax' | r | xlat}}</span>
-            <span class="pull-right">{{currentOrder.TaxCost || 0 | culturecurrency}}</span>
+            <span ng-show="currentOrder.TaxCost && currentOrder.TaxCost > 0" class="pull-right">{{currentOrder.TaxCost | culturecurrency}}</span>
         </p>
         <div ng-show="user.Permissions.contains('ViewPromotions')">
             <div ng-show="!currentOrder.Coupon">


### PR DESCRIPTION
The culturecurrency filter was updated in this app to work with $0.00 prices which caused tax to now display.  I added logic to hide tax when the amount is $0.00.